### PR TITLE
addresses issue #2

### DIFF
--- a/main.js
+++ b/main.js
@@ -127,7 +127,7 @@ define(function (require, exports, module) {
         initGutter: function(editor) {
 
             var cm = editor._codeMirror;
-            var gutters = cm.getOption("gutters");
+            var gutters = cm.getOption("gutters").slice(0);
             var str = gutters.join('');
             if (str.indexOf(gutterName) === -1) {
                 gutters.unshift(gutterName);


### PR DESCRIPTION
Setting the gutter elements dont behave as expected when the original array returned from cm.getOption("gutters") is used. Instead make a new copy of the array using Array.slice(0) API.
